### PR TITLE
Allow partOfSpeech attribute in getDefinitions to accept an array

### DIFF
--- a/src/WordnikAPI.ts
+++ b/src/WordnikAPI.ts
@@ -101,7 +101,7 @@ export default class WordnikAPI {
      */
     public async getDefinitions(word: string,
                                 limit: number = 1,
-                                partOfSpeech: PartOfSpeech | undefined = undefined,
+                                partOfSpeech: PartOfSpeech[] | PartOfSpeech | undefined = undefined,
                                 sourceDictionary: "all" | "ahd-5" | "century" | "wiktionary" | "webster" | "wordnet" = "all",
                                 useCanonical: boolean = false,
                                 includeTags: boolean = false): Promise<Word[] | null> {


### PR DESCRIPTION
The [Wordnik docs](https://developer.wordnik.com/docs#!/word/getDefinitions) mention that `partOfSpeech` is a "CSV list of part-of-speech types". That means we should be able to pass multiple parts of speech to the `getDefinitions` endpoint.

This PR updates the types of `getDefinitions` to accept `PartOfSpeech | PartOfSpeech[] | undefined`. Since you're already calling `partOfSpeech?.toString()`, the array will be joined with commas, which is exactly how Wordnik expects it.